### PR TITLE
[WFLY-9620] Improve the test code and add required permissions in order to be able to run it under sec manager

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/overlays/PathAccessCheckServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/overlays/PathAccessCheckServlet.java
@@ -28,10 +28,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Paths;
 
 /**
  * @author  Jaikiran Pai
@@ -42,17 +40,8 @@ public class PathAccessCheckServlet extends HttpServlet {
     static final String ACCESS_CHECKS_CORRECTLY_VALIDATED = "access-checks-valid";
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        final String action = req.getParameter("create_file");
-        if ( Boolean.valueOf(action) ){
-            File file = Paths.get(System.getProperty("java.io.tmpdir"), "noaccess.txt").toFile();
-            if ( file.createNewFile() ) {
-                resp.getWriter().write(file.getAbsolutePath());
-            }else{
-                resp.getWriter().write("");
-            }
-            return;
-        }
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
         final String path = req.getParameter("path");
         final String shouldBeAccessible = req.getParameter("expected-accessible");
         final boolean expectedAccessible = shouldBeAccessible == null ? false : Boolean.parseBoolean(shouldBeAccessible);

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/overlays/ServletResourceOverlaysTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/overlays/ServletResourceOverlaysTestCase.java
@@ -21,7 +21,11 @@
  */
 package org.jboss.as.test.integration.web.servlet.overlays;
 
+import java.io.File;
+import java.io.FilePermission;
 import java.net.URL;
+import java.nio.file.Paths;
+import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -37,7 +41,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  */
@@ -54,6 +60,10 @@ public class ServletResourceOverlaysTestCase {
         war.addAsWebResource(new StringAsset("a"), "a.txt");
         war.addAsWebResource(new StringAsset("b"), "b.txt");
         war.addClass(PathAccessCheckServlet.class);
+        war.addAsManifestResource(createPermissionsXmlAsset(
+                new FilePermission("/-", "read"),
+                new PropertyPermission("java.io.tmpdir","read")
+        ), "permissions.xml");
 
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar");
         jar.addAsManifestResource(new StringAsset("b - overlay"), new BasicPath("resources", "b.txt"));
@@ -89,12 +99,15 @@ public class ServletResourceOverlaysTestCase {
         final String aTxtPath = "a.txt";
         final String aTxtAccess = performCall(url, "/check-path-access?path=a.txt&expected-accessible=true");
         assertEquals("Unexpected result from call to " + aTxtPath, PathAccessCheckServlet.ACCESS_CHECKS_CORRECTLY_VALIDATED, aTxtAccess);
+        File fileUnderTest = Paths.get(System.getProperty("java.io.tmpdir"), "noaccess.txt").toFile();
+        fileUnderTest.createNewFile();
 
-        final String fileUnderTest = performCall(url, "/check-path-access?create_file=true");
-        if ( !"".equals(fileUnderTest) ){
-            final String pathOutsideOfDeployment = "/../../../../../../../../"+fileUnderTest;
+        if ( fileUnderTest.exists() ){
+            final String pathOutsideOfDeployment = "/../../../../../../../../"+ fileUnderTest.getAbsolutePath();
             final String outsidePathAccessCheck = performCall(url, "/check-path-access?path=" + pathOutsideOfDeployment + "&expected-accessible=false");
             assertEquals("Unexpected result from call to " + pathOutsideOfDeployment, PathAccessCheckServlet.ACCESS_CHECKS_CORRECTLY_VALIDATED, outsidePathAccessCheck);
+        } else {
+            fail("Cannot create the file under test: " + fileUnderTest.getAbsolutePath() );
         }
     }
 }


### PR DESCRIPTION
Hello Jairan, this is an updated PR in order to fix the latest test failures found aginst wildfly master.

Apart from adding the required permissions for the security manager, I removed the code which gets the java.io.tmpdir from the server VM, by default we are going to have the same folder in the arquillian client test and in the server, so it is not necessary to get the value viewed by the servlet.

Would you mind rebasing your PR and trigger a new one including these latest changes?